### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: System dependencies (Ubuntu)
       run: |
         sudo apt-get update
-        sudo apt-get install latexmk fonts-firacode
+        sudo apt-get install fonts-firacode fonts-liberation fonts-lmodern -y
         pip install pygments latexminted
 
     - name: Download Libertinus Fonts

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,16 @@ Relectures/
 Defence/
 
 Videos/
+
+Manuscript/main.dep
+
+Manuscript/main.fdb_latexmk
+
+Manuscript/main.fls
+
+Manuscript/main.mw.mw
+
+Manuscript/main.xdv
+
+github-secret.token
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# act -P=ubuntu-22.04=<this image> --pull=false --secret-file <file with "GITHUB_TOKEN=...">
+# Fixing path of this image (makes it surprisingly big)
+FROM catthehacker/ubuntu:js-22.04
+ENV PATH="/opt/acttoolcache/node/20.18.0/x64/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"

--- a/thesis-deps.txt
+++ b/thesis-deps.txt
@@ -109,6 +109,7 @@ kvdefinekeys
 kvoptions
 kvsetkeys
 l3keys2e
+latexmk
 letltxmacro
 lineno
 listings


### PR DESCRIPTION
It's possible to install latexmk via TexLive mangage rather than Ubuntu, and this reduces the amount of stuff Ubuntu needs to install by a fair bit and takes advantage of the TexLive action caching. Doing this causes a few headaches with fonts which for some reason are best installed via apt-get.

This commit also adds a Dockerfile with instructions on how to run the CI locally with https://nektosact.com/