### PR TITLE
Update CI to reroute setup-texlive-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: recursive
 
     - name: Setup TeX Live
-      uses: teatimeguest/setup-texlive-action@v3
+      uses: muzimuzhi/setup-texlive-action@v3
       with:
         version: 2024
         package-file: thesis-deps.txt


### PR DESCRIPTION
@teatimeguest deleted their acccount, including their repos and thus their setup-texlive-action.

@muzimuzhi has resourcefully resurrected the action temporarily and so this commit uses that for now.