### PR TITLE
Fix OCaml lexer wildcard pattern handling in Pygments

### DIFF
--- a/.github/scripts/patch_ocaml_lexer.py
+++ b/.github/scripts/patch_ocaml_lexer.py
@@ -1,0 +1,35 @@
+"""Patch Pygments' OCaml lexer so a leading run of underscores (e.g. the
+"__" in "__FUNCTION__") is treated as part of the identifier instead of
+being split into standalone wildcard-pattern '_' tokens.
+
+Pygments' OcamlLexer.keyopts matches a bare '_' with no boundary check, so
+it always wins the wildcard-pattern match even when it is part of a longer
+identifier. OCaml's own grammar defines the wildcard as a *standalone* '_'
+token, so this only matches '_' when it is not followed by another
+identifier character. A plain \\b boundary is not enough: OCaml identifiers
+may continue with a prime (e.g. "_'"), and ' is not a \\w character, so \\b
+would still misfire on that case.
+
+Run this after installing pygments, before any minted-based build. It
+edits the installed package in place and fails loudly if pygments'
+internals no longer match what is expected here, so CI breaks visibly
+instead of silently reverting to the old (buggy) behaviour.
+"""
+
+import pygments.lexers.ml as m
+
+path = m.__file__
+text = open(path, encoding="utf-8").read()
+
+start = text.index("class OcamlLexer(RegexLexer):")
+end = text.index("class OpaLexer(RegexLexer):", start)
+body = text[start:end]
+
+old = "']', '_', '`',"
+new = "']', r\"_(?![\\w'])\", '`',"
+assert old in body, "OcamlLexer keyopts text not found; pygments internals changed"
+body = body.replace(old, new, 1)
+
+text = text[:start] + body + text[end:]
+open(path, "w", encoding="utf-8").write(text)
+print(f"Patched OcamlLexer wildcard handling in {path}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install fonts-firacode fonts-liberation fonts-lmodern opam -y
         pip install pygments latexminted
+        python3 .github/scripts/patch_ocaml_lexer.py
         pip install -e src/cn_lexer
 
     - name: Download Libertinus Fonts


### PR DESCRIPTION
## Summary
This PR adds a patch script to fix Pygments' OCaml lexer so that leading underscores in identifiers (like `__FUNCTION__`) are correctly treated as part of the identifier rather than being split into separate wildcard-pattern tokens.

## Changes
- **Added `.github/scripts/patch_ocaml_lexer.py`**: A new patch script that modifies the installed Pygments package to fix the OCaml lexer's handling of the wildcard `_` pattern. The script:
  - Replaces the bare `'_'` pattern in `OcamlLexer.keyopts` with a negative lookahead regex `r"_(?![\w'])"` to ensure `_` only matches as a standalone token
  - Includes validation to detect if Pygments internals have changed, failing loudly rather than silently reverting to buggy behavior
  - Includes detailed documentation explaining the issue and the fix

- **Modified `.github/workflows/ci.yml`**: Added execution of the patch script in the CI workflow after installing Pygments and before any minted-based builds

## Implementation Details
The fix uses a negative lookahead assertion `(?![\w'])` to ensure the wildcard `_` only matches when not followed by word characters or a prime (`'`), which aligns with OCaml's grammar definition of a standalone wildcard token. This prevents identifiers like `__FUNCTION__` from being incorrectly tokenized.

https://claude.ai/code/session_01GCGURbrA2DVAQiShooL56t