### PR TITLE
ci: pin TeX Live repository to work around expired cert on default hi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       uses: TeX-Live/setup-texlive-action@v3
       with:
         version: 2024
+        # ftp.math.utah.edu (the action's default historic mirror) has an expired
+        # TLS cert; pin to a mirror known to work for the 2024 tlnet-final archive.
+        repository: https://mirrors.tuna.tsinghua.edu.cn/tex-historic-archive/systems/texlive/2024/tlnet-final/
         package-file: thesis-deps.txt
 
     - name: System dependencies (Ubuntu)


### PR DESCRIPTION
…storic mirror

ftp.math.utah.edu (setup-texlive-action's default historic-archive host) is serving an expired TLS certificate, breaking install-tl downloads for the pinned TeX Live 2024. Point repository at the Tsinghua historic mirror instead, which is a valid HTTPS host for the 2024 tlnet-final archive.