### PR TITLE
Fix double-underscore ligature by patching TeX Live's bundled Pygments wheel

### DIFF
--- a/.github/scripts/patch_ocaml_lexer.py
+++ b/.github/scripts/patch_ocaml_lexer.py
@@ -10,26 +10,58 @@ identifier character. A plain \\b boundary is not enough: OCaml identifiers
 may continue with a prime (e.g. "_'"), and ' is not a \\w character, so \\b
 would still misfire on that case.
 
-Run this after installing pygments, before any minted-based build. It
-edits the installed package in place and fails loudly if pygments'
-internals no longer match what is expected here, so CI breaks visibly
+`pip install pygments` is not enough to fix this for real builds: TeX
+Live's `setup-texlive-action` ships its own self-contained `latexminted`
+executable, bundled with its own `pygments-*.whl` sitting next to it on
+disk. That executable's launcher script prepends its bundled wheels to
+`sys.path` itself, so it never sees a separately pip-installed Pygments
+regardless of PATH order -- and forcing a *different* latexminted onto
+PATH breaks minted's own version-compatibility check instead (it expects
+the exact latexminted build TeX Live shipped). So this patches the
+OCaml lexer directly inside that bundled wheel (a zip file), in place,
+without touching which `latexminted` executable actually runs or its
+declared version.
+
+Run this once latexminted is available on PATH (i.e. after "Setup TeX
+Live"). It fails loudly if pygments' internals, or the bundled wheel
+layout, no longer match what is expected here, so CI breaks visibly
 instead of silently reverting to the old (buggy) behaviour.
 """
 
-import pygments.lexers.ml as m
+import shutil
+import sys
+import zipfile
+from pathlib import Path
 
-path = m.__file__
-text = open(path, encoding="utf-8").read()
+latexminted_path = shutil.which("latexminted")
+assert latexminted_path, "latexminted not found on PATH"
 
-start = text.index("class OcamlLexer(RegexLexer):")
-end = text.index("class OpaLexer(RegexLexer):", start)
-body = text[start:end]
+latexminted_dir = Path(latexminted_path).resolve().parent
+wheel_paths = list(latexminted_dir.glob("pygments*.whl"))
+assert wheel_paths, f"no pygments*.whl found next to {latexminted_path}"
+assert len(wheel_paths) == 1, f"expected exactly one pygments wheel, found {wheel_paths}"
+wheel_path = wheel_paths[0]
+
+with zipfile.ZipFile(wheel_path, "r") as zf:
+    names = zf.namelist()
+    ml_names = [n for n in names if n.endswith("pygments/lexers/ml.py")]
+    assert len(ml_names) == 1, f"expected exactly one pygments/lexers/ml.py entry, found {ml_names}"
+    ml_name = ml_names[0]
+    contents = {n: zf.read(n) for n in names}
+    infos = {n: zf.getinfo(n) for n in names}
+
+text = contents[ml_name].decode("utf-8")
 
 old = "']', '_', '`',"
 new = "']', r\"_(?![\\w'])\", '`',"
-assert old in body, "OcamlLexer keyopts text not found; pygments internals changed"
-body = body.replace(old, new, 1)
+assert old in text, f"OcamlLexer keyopts text not found in {ml_name}; pygments internals changed"
+text = text.replace(old, new, 1)
+contents[ml_name] = text.encode("utf-8")
 
-text = text[:start] + body + text[end:]
-open(path, "w", encoding="utf-8").write(text)
-print(f"Patched OcamlLexer wildcard handling in {path}")
+tmp_path = wheel_path.with_suffix(".whl.tmp")
+with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+    for name, data in contents.items():
+        zf.writestr(infos[name], data)
+tmp_path.replace(wheel_path)
+
+print(f"Patched {ml_name} inside {wheel_path}", file=sys.stderr)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install fonts-firacode fonts-liberation fonts-lmodern opam -y
-        # EXPERIMENT: deliberately NOT running `pip install pygments latexminted`
-        # here, to confirm the real build never needed it -- TeX Live's own
-        # bundled latexminted (with its own pygments-*.whl) should be entirely
-        # self-sufficient, including for cn_lexer's runtime `import pygments`.
+        # No separate `pip install pygments latexminted` needed: TeX Live's own
+        # bundled latexminted (with its own pygments-*.whl) is self-sufficient,
+        # including for cn_lexer's runtime `import pygments` below.
         pip install -e src/cn_lexer
         # Patches the pygments-*.whl that TeX Live's own latexminted executable
         # bundles next to itself. See the script for why.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,18 @@ jobs:
         mv main.tex old_minted.tex && tail -n +2 old_minted.tex > main.tex # hack to build with newer version of minted
         sed -i 's~% \\sloppy~\\sloppy~g' kaobook/kaobook.cls # better breaking for long lines
         eval $(opam env --switch=${{ matrix.version }})
+        echo "::group::DIAGNOSTIC: OCaml lexer patch state at build time"
+        which python3
+        python3 --version
+        python3 -c "from pygments.lexers import find_lexer_class_by_name; print(find_lexer_class_by_name('ocaml').keyopts)"
+        which latexminted || true
+        head -1 "$(which latexminted)" || true
+        which pygmentize || true
+        echo "::endgroup::"
         make || (cat _build/*.log; exit 1)
+        echo "::group::DIAGNOSTIC: generated minted cache content for FUNCTION"
+        grep -rl "FUNCTION" _build/ 2>/dev/null | while read -r f; do echo "--- $f ---"; cat "$f"; done
+        echo "::endgroup::"
         texcount -inc main.tex | tee _build/wordcount.tex
 
     - name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,13 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install fonts-firacode fonts-liberation fonts-lmodern opam -y
-        pip install pygments latexminted
+        # EXPERIMENT: deliberately NOT running `pip install pygments latexminted`
+        # here, to confirm the real build never needed it -- TeX Live's own
+        # bundled latexminted (with its own pygments-*.whl) should be entirely
+        # self-sufficient, including for cn_lexer's runtime `import pygments`.
         pip install -e src/cn_lexer
         # Patches the pygments-*.whl that TeX Live's own latexminted executable
-        # bundles next to itself (not the pip-installed pygments above, which
-        # that executable ignores). See the script for why.
+        # bundles next to itself. See the script for why.
         python3 .github/scripts/patch_ocaml_lexer.py
 
     - name: Download Libertinus Fonts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,20 +84,16 @@ jobs:
         mv main.tex old_minted.tex && tail -n +2 old_minted.tex > main.tex # hack to build with newer version of minted
         sed -i 's~% \\sloppy~\\sloppy~g' kaobook/kaobook.cls # better breaking for long lines
         eval $(opam env --switch=${{ matrix.version }})
-        echo "::group::DIAGNOSTIC: OCaml lexer patch state at build time"
-        which python3
-        python3 --version
-        python3 -c "from pygments.lexers import find_lexer_class_by_name; print(find_lexer_class_by_name('ocaml').keyopts)"
-        echo "PATH=$PATH"
-        echo "--- latexminted resolution ---"
-        which -a latexminted || true
-        cat "$(which latexminted)" || true
-        echo "--- any pygments/lexers/ml.py on disk ---"
-        find / -path '*/pygments/lexers/ml.py' 2>/dev/null | while read -r f; do
-          echo "=== $f ==="
-          grep -n "'_', '\`'\|_(?!" "$f" || echo "(no keyopts match found)"
-        done
-        echo "::endgroup::"
+        # TeX Live's setup-texlive-action ships its own latexminted executable
+        # bundled with its own vendored Pygments wheel, on PATH ahead of the
+        # one `pip install --user latexminted` provides, so the patch to
+        # site-packages/pygments above is otherwise silently ignored. Put the
+        # pip-installed one first; this is the mechanism latexminted's own
+        # entry-point script documents for using a separately customized
+        # Pygments (see its docstring: "it is possible to modify PATH so that
+        # the desired latexminted executable is first").
+        export PATH="$HOME/.local/bin:$PATH"
+        which latexminted
         make || (cat _build/*.log; exit 1)
         echo "::group::DIAGNOSTIC: generated minted cache content for FUNCTION"
         grep -rl "FUNCTION" _build/ 2>/dev/null | while read -r f; do echo "--- $f ---"; cat "$f"; done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,15 @@ jobs:
         which python3
         python3 --version
         python3 -c "from pygments.lexers import find_lexer_class_by_name; print(find_lexer_class_by_name('ocaml').keyopts)"
-        which latexminted || true
-        head -1 "$(which latexminted)" || true
-        which pygmentize || true
+        echo "PATH=$PATH"
+        echo "--- latexminted resolution ---"
+        which -a latexminted || true
+        cat "$(which latexminted)" || true
+        echo "--- any pygments/lexers/ml.py on disk ---"
+        find / -path '*/pygments/lexers/ml.py' 2>/dev/null | while read -r f; do
+          echo "=== $f ==="
+          grep -n "'_', '\`'\|_(?!" "$f" || echo "(no keyopts match found)"
+        done
         echo "::endgroup::"
         make || (cat _build/*.log; exit 1)
         echo "::group::DIAGNOSTIC: generated minted cache content for FUNCTION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install fonts-firacode fonts-liberation fonts-lmodern opam -y
         pip install pygments latexminted
-        python3 .github/scripts/patch_ocaml_lexer.py
         pip install -e src/cn_lexer
+        # Patches the pygments-*.whl that TeX Live's own latexminted executable
+        # bundles next to itself (not the pip-installed pygments above, which
+        # that executable ignores). See the script for why.
+        python3 .github/scripts/patch_ocaml_lexer.py
 
     - name: Download Libertinus Fonts
       uses: robinraju/release-downloader@v1
@@ -84,20 +87,7 @@ jobs:
         mv main.tex old_minted.tex && tail -n +2 old_minted.tex > main.tex # hack to build with newer version of minted
         sed -i 's~% \\sloppy~\\sloppy~g' kaobook/kaobook.cls # better breaking for long lines
         eval $(opam env --switch=${{ matrix.version }})
-        # TeX Live's setup-texlive-action ships its own latexminted executable
-        # bundled with its own vendored Pygments wheel, on PATH ahead of the
-        # one `pip install --user latexminted` provides, so the patch to
-        # site-packages/pygments above is otherwise silently ignored. Put the
-        # pip-installed one first; this is the mechanism latexminted's own
-        # entry-point script documents for using a separately customized
-        # Pygments (see its docstring: "it is possible to modify PATH so that
-        # the desired latexminted executable is first").
-        export PATH="$HOME/.local/bin:$PATH"
-        which latexminted
         make || (cat _build/*.log; exit 1)
-        echo "::group::DIAGNOSTIC: generated minted cache content for FUNCTION"
-        grep -rl "FUNCTION" _build/ 2>/dev/null | while read -r f; do echo "--- $f ---"; cat "$f"; done
-        echo "::endgroup::"
         texcount -inc main.tex | tee _build/wordcount.tex
 
     - name: Release


### PR DESCRIPTION
Supersedes PR #98's CI-side fix, which patched a pip-installed copy of Pygments that the real build never actually used.

**What went wrong with #98:** the released PDF still showed `__FUNCTION__` rendering inconsistently (mismatched Fira Code ligature glyphs on the leading vs. trailing `__`) even though the patch script reported success. Root cause: TeX Live's `setup-texlive-action` ships its own self-contained `latexminted` executable, bundled with its own `pygments-*.whl` sitting next to it on disk — completely separate from anything `pip install pygments` touches, and it wins on `PATH` ahead of a pip-installed one. Confirmed directly from a real CI build's generated minted cache, which still showed the old split-token output.

I also tried reordering `PATH` so the pip-installed `latexminted` would win instead — that broke minted entirely (`Cannot highlight code (minted executable is unavailable or disabled)`), because minted checks the *version* of whichever `latexminted` runs, and the pip-installed one wasn't the version TeX Live actually shipped.

**The actual fix:** `.github/scripts/patch_ocaml_lexer.py` now locates the `latexminted` executable that will really run (`shutil.which`, no `PATH` changes), finds the `pygments-*.whl` bundled next to it, and edits `pygments/lexers/ml.py` directly inside that zip via the `zipfile` module. This never touches which executable or version actually runs, so minted's compatibility check is unaffected.

Verified end-to-end against the real CI environment (not just a local reproduction): the generated `.highlight.minted` cache content now shows `__FUNCTION__` as a single merged `\PYG{n}{...}` token instead of split `Operator`/`Name` tokens.

Also confirmed via a separate CI run that `pip install pygments latexminted` was never actually necessary for the real build (the TeX-Live-bundled copy is self-sufficient, including for `cn_lexer`'s runtime `import pygments`), so that line is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCGURbrA2DVAQiShooL56t)_